### PR TITLE
Disallow floating for emoji images.

### DIFF
--- a/emoji.js
+++ b/emoji.js
@@ -56,7 +56,8 @@ function get_replacement(matched) {
 		element += " title='" + name + "' alt='" + name + "' ";
 	}
 	element += "style='height:" + scale + "em !important; ";
-	element += "width:" + scale + "em !important' ";
+	element += "width:" + scale + "em !important; ";
+	element += "float:none !important' ";
 	element += ">";
 	return element;
 }


### PR DESCRIPTION
This fixes some rendering issues experienced, for example, when a user on Dribbble has an emoji in their username (which appears in an area where all images are floated).

It can be tested at [this page](http://dribbble.com/shots/1140053-Air-Ticket?list=popular&offset=12) in Chrome on Windows 7, when native fonts are disabled.
