### PR TITLE
Do not clone all elements when finding text

### DIFF
--- a/emoji.js
+++ b/emoji.js
@@ -1,7 +1,5 @@
 ﻿jQuery.fn.just_text = function() {
-    return $(this).clone()
-        .children()
-        .remove()
+    return $(this).children()
         .end()
         .text();
 }


### PR DESCRIPTION
Proposed fix for #33

This stops cloning the elements, and simply performs the text operation on the elements as they are in the DOM.

As the element references are not re-used anywhere, this doesn't appear to be an issue or have any detrimental effect upon performance as far as I can tell.

This does, however, prevent resources referenced in the contents from being reloaded if the cached data is invalid.

A test case for this issue, and this fix, can be found at https://oevf.aec.gov.au/VerifyEnrolment.aspx - the state of the image and audio CAPTCHA is inconsistent when Chromoji is enabled without this patch, and consistent when the patch is applied, or Chromoji disabled.
