### PR TITLE
Avoid throwing error when filtering undefined elements

### DIFF
--- a/emoji.js
+++ b/emoji.js
@@ -8,10 +8,12 @@ function filter_nodes(nodes, regexp) {
     return $(nodes).find('[contenteditable!="true"][contenteditable!="plaintext-only"]').addBack().filter(
         function(index) {
 			var result = false;
-			var text = $(this).just_text();
+			var $this = this ? $(this) : null;
+			if (!$this) { return result; }
+			var text = $this.just_text();
             var found = (text.search(regexp) != -1)
 			if(found) {
-				var html = $(this).html();
+				var html = $this.html();
 				if(html) {
 					var index = html.indexOf("document.write");
 					result = (index == -1);

--- a/emoji.js
+++ b/emoji.js
@@ -9,7 +9,7 @@ function filter_nodes(nodes, regexp) {
         function(index) {
 			var result = false;
 			var $this = this ? $(this) : null;
-			if (!$this) { return result; }
+			if (!$this || !$this.just_text) { return result; }
 			var text = $this.just_text();
             var found = (text.search(regexp) != -1)
 			if(found) {


### PR DESCRIPTION
When a site uses [`jQuery.append`](http://api.jquery.com/append/) to insert HTML that contains emoji, the script will fail and kill the function that called `.append`. (Strangely, the same does not happen for `jQuery.prepend`.)

This pull request:
1. verifies that `.just_text` is an acceptable method before moving on
2. caches `$(this)` for better performance (regardless of this bug)

![image](https://f.cloud.github.com/assets/262137/2066330/834ceeaa-8ced-11e3-9d09-88e81c79d3d9.png)
